### PR TITLE
Finding Allowlist & Suppression

### DIFF
--- a/.clawpinch-ignore.json
+++ b/.clawpinch-ignore.json
@@ -1,8 +1,0 @@
-{
-  "suppressions": [
-    {
-      "id": "CHK-CFG-001",
-      "reason": "Test suppression with no expiry date"
-    }
-  ]
-}

--- a/.clawpinch-ignore.json
+++ b/.clawpinch-ignore.json
@@ -1,0 +1,8 @@
+{
+  "suppressions": [
+    {
+      "id": "CHK-CFG-001",
+      "reason": "Test suppression with no expiry date"
+    }
+  ]
+}

--- a/.clawpinch-ignore.json.example
+++ b/.clawpinch-ignore.json.example
@@ -1,15 +1,53 @@
 {
+  "$schema": "https://clawpinch.dev/schemas/ignore.json",
+  "_comment": "This file configures finding suppression for ClawPinch security scans",
+  "_documentation": {
+    "purpose": "Suppress accepted-risk findings to prevent CI/CD pipeline failures",
+    "location": "Copy this file to .clawpinch-ignore.json in your project root",
+    "fields": {
+      "id": "(required) Check ID to suppress (e.g., CHK-CFG-001)",
+      "reason": "(required) Justification for suppressing this finding",
+      "expires": "(optional) ISO 8601 timestamp when suppression expires and finding reactivates",
+      "suppressed_by": "(optional) Email or identifier of person who approved suppression",
+      "suppressed_at": "(optional) ISO 8601 timestamp when suppression was created"
+    },
+    "behavior": {
+      "suppressed_findings": "Moved to 'suppressed' array in JSON output, excluded from severity counts",
+      "expired_suppressions": "Automatically reactivated if expires date is in the past",
+      "flags": {
+        "--show-suppressed": "Include suppressed findings in output with [SUPPRESSED] marker",
+        "--no-ignore": "Disable all suppressions for full audit scans"
+      }
+    }
+  },
   "suppressions": [
     {
       "id": "CHK-CFG-001",
-      "reason": "Dev environment - open gateway is intentional",
-      "expires": "2099-12-31T23:59:59Z",
+      "reason": "Dev environment - open gateway is intentional for local testing",
+      "expires": "2025-12-31T23:59:59Z",
       "suppressed_by": "devops@example.com",
       "suppressed_at": "2024-01-15T10:30:00Z"
     },
     {
       "id": "CHK-SEC-003",
-      "reason": "Test API key in example config - not used in production"
+      "reason": "Test API key in example config - not used in production deployments"
+    },
+    {
+      "id": "CHK-NET-004",
+      "reason": "WebSocket endpoint exposed for real-time collaboration feature",
+      "expires": "2025-06-30T00:00:00Z",
+      "suppressed_by": "security-team@example.com"
+    },
+    {
+      "id": "CHK-PRM-002",
+      "reason": "Wildcard permission required for dynamic skill loader - reviewed by security",
+      "suppressed_by": "ciso@example.com",
+      "suppressed_at": "2024-02-20T14:30:00Z"
+    },
+    {
+      "id": "CHK-CRN-001",
+      "reason": "Cron job needs elevated permissions for system maintenance tasks",
+      "expires": "2025-03-01T00:00:00Z"
     }
   ]
 }

--- a/.clawpinch-ignore.json.example
+++ b/.clawpinch-ignore.json.example
@@ -1,0 +1,15 @@
+{
+  "suppressions": [
+    {
+      "id": "CHK-CFG-001",
+      "reason": "Dev environment - open gateway is intentional",
+      "expires": "2099-12-31T23:59:59Z",
+      "suppressed_by": "devops@example.com",
+      "suppressed_at": "2024-01-15T10:30:00Z"
+    },
+    {
+      "id": "CHK-SEC-003",
+      "reason": "Test API key in example config - not used in production"
+    }
+  ]
+}

--- a/clawpinch.sh
+++ b/clawpinch.sh
@@ -14,6 +14,7 @@ source "$HELPERS_DIR/common.sh"
 source "$HELPERS_DIR/report.sh"
 source "$HELPERS_DIR/redact.sh"
 source "$HELPERS_DIR/interactive.sh"
+source "$HELPERS_DIR/suppression.sh"
 
 # ─── Signal trap for animation cleanup ──────────────────────────────────────
 
@@ -351,18 +352,47 @@ SORTED_FINDINGS="$(echo "$ALL_FINDINGS" | jq '
   sort_by(.severity | sev_order)
 ')"
 
-# ─── Count by severity ──────────────────────────────────────────────────────
+# ─── Apply suppression filtering ─────────────────────────────────────────────
 
-count_critical="$(echo "$SORTED_FINDINGS" | jq '[.[] | select(.severity == "critical")] | length')"
-count_warn="$(echo "$SORTED_FINDINGS"     | jq '[.[] | select(.severity == "warn")] | length')"
-count_info="$(echo "$SORTED_FINDINGS"     | jq '[.[] | select(.severity == "info")] | length')"
-count_ok="$(echo "$SORTED_FINDINGS"       | jq '[.[] | select(.severity == "ok")] | length')"
+ACTIVE_FINDINGS="$SORTED_FINDINGS"
+SUPPRESSED_FINDINGS="[]"
+
+# Apply filtering unless --no-ignore is set
+if [[ "$NO_IGNORE" -eq 0 ]]; then
+  # Look for .clawpinch-ignore.json in the OpenClaw config directory or current directory
+  ignore_file=".clawpinch-ignore.json"
+  if [[ -n "$OPENCLAW_CONFIG" ]] && [[ -f "$OPENCLAW_CONFIG/.clawpinch-ignore.json" ]]; then
+    ignore_file="$OPENCLAW_CONFIG/.clawpinch-ignore.json"
+  fi
+
+  # Filter findings into active and suppressed
+  if [[ -f "$ignore_file" ]]; then
+    filtered_result="$(echo "$SORTED_FINDINGS" | filter_findings "$ignore_file")"
+    ACTIVE_FINDINGS="$(echo "$filtered_result" | jq -c '.active')"
+    SUPPRESSED_FINDINGS="$(echo "$filtered_result" | jq -c '.suppressed')"
+  fi
+fi
+
+# For --show-suppressed mode, merge suppressed back into active for display
+DISPLAY_FINDINGS="$ACTIVE_FINDINGS"
+if [[ "$SHOW_SUPPRESSED" -eq 1 ]]; then
+  DISPLAY_FINDINGS="$(echo "$ACTIVE_FINDINGS" "$SUPPRESSED_FINDINGS" | jq -s '.[0] + .[1] | sort_by(.severity | if . == "critical" then 0 elif . == "warn" then 1 elif . == "info" then 2 elif . == "ok" then 3 else 4 end)')"
+fi
+
+# ─── Count by severity ──────────────────────────────────────────────────────
+# Count only active findings (not suppressed) for exit code calculation
+
+count_critical="$(echo "$ACTIVE_FINDINGS" | jq '[.[] | select(.severity == "critical")] | length')"
+count_warn="$(echo "$ACTIVE_FINDINGS"     | jq '[.[] | select(.severity == "warn")] | length')"
+count_info="$(echo "$ACTIVE_FINDINGS"     | jq '[.[] | select(.severity == "info")] | length')"
+count_ok="$(echo "$ACTIVE_FINDINGS"       | jq '[.[] | select(.severity == "ok")] | length')"
 
 # ─── Output ──────────────────────────────────────────────────────────────────
 
 if [[ "$JSON_OUTPUT" -eq 1 ]]; then
-  # Pure JSON output (compact for piping efficiency)
-  echo "$SORTED_FINDINGS" | jq -c .
+  # Pure JSON output with findings and suppressed arrays
+  jq -n -c --argjson findings "$ACTIVE_FINDINGS" --argjson suppressed "$SUPPRESSED_FINDINGS" \
+    '{findings: $findings, suppressed: $suppressed}'
 else
   if [[ "$QUIET" -eq 0 ]]; then
     # Determine if interactive mode is available
@@ -373,13 +403,13 @@ else
 
     if [[ "$_is_interactive" -eq 1 ]]; then
       # Compact grouped table (new v1.1 display)
-      print_findings_compact "$SORTED_FINDINGS"
+      print_findings_compact "$DISPLAY_FINDINGS"
     else
       # Non-interactive fallback: full card display (v1.0 behavior)
-      total="$(echo "$SORTED_FINDINGS" | jq 'length')"
+      total="$(echo "$DISPLAY_FINDINGS" | jq 'length')"
       if (( total > 0 )); then
         for i in $(seq 0 $((total - 1))); do
-          finding="$(echo "$SORTED_FINDINGS" | jq -c ".[$i]")"
+          finding="$(echo "$DISPLAY_FINDINGS" | jq -c ".[$i]")"
           print_finding "$finding"
         done
       else
@@ -396,7 +426,7 @@ else
 
   # Launch interactive menu if TTY and not disabled
   if [[ "$QUIET" -eq 0 ]] && [[ "$NO_INTERACTIVE" -eq 0 ]] && [[ -t 0 ]]; then
-    interactive_menu "$SORTED_FINDINGS" "$scanner_count" "$_scan_elapsed"
+    interactive_menu "$DISPLAY_FINDINGS" "$scanner_count" "$_scan_elapsed"
   fi
 
   # ─── AI Remediation pipeline ─────────────────────────────────────────────
@@ -413,7 +443,7 @@ else
     if [[ -z "$_claude_bin" ]]; then
       log_error "Claude CLI not found. Install it or set CLAWPINCH_CLAUDE_BIN."
     else
-      _non_ok_findings="$(echo "$SORTED_FINDINGS" | jq -c '[.[] | select(.severity != "ok")]')"
+      _non_ok_findings="$(echo "$ACTIVE_FINDINGS" | jq -c '[.[] | select(.severity != "ok")]')"
       _non_ok_count="$(echo "$_non_ok_findings" | jq 'length')"
 
       if (( _non_ok_count > 0 )); then

--- a/clawpinch.sh
+++ b/clawpinch.sh
@@ -376,7 +376,9 @@ fi
 # For --show-suppressed mode, merge suppressed back into active for display
 DISPLAY_FINDINGS="$ACTIVE_FINDINGS"
 if [[ "$SHOW_SUPPRESSED" -eq 1 ]]; then
-  DISPLAY_FINDINGS="$(echo "$ACTIVE_FINDINGS" "$SUPPRESSED_FINDINGS" | jq -s '.[0] + .[1] | sort_by(.severity | if . == "critical" then 0 elif . == "warn" then 1 elif . == "info" then 2 elif . == "ok" then 3 else 4 end)')"
+  # Mark suppressed findings with a "suppressed": true field before merging
+  MARKED_SUPPRESSED="$(echo "$SUPPRESSED_FINDINGS" | jq '[.[] | . + {suppressed: true}]')"
+  DISPLAY_FINDINGS="$(echo "$ACTIVE_FINDINGS" "$MARKED_SUPPRESSED" | jq -s '.[0] + .[1] | sort_by(.severity | if . == "critical" then 0 elif . == "warn" then 1 elif . == "info" then 2 elif . == "ok" then 3 else 4 end)')"
 fi
 
 # ─── Count by severity ──────────────────────────────────────────────────────

--- a/clawpinch.sh
+++ b/clawpinch.sh
@@ -361,8 +361,8 @@ SUPPRESSED_FINDINGS="[]"
 if [[ "$NO_IGNORE" -eq 0 ]]; then
   # Look for .clawpinch-ignore.json in the OpenClaw config directory or current directory
   ignore_file=".clawpinch-ignore.json"
-  if [[ -n "$OPENCLAW_CONFIG" ]] && [[ -f "$OPENCLAW_CONFIG/.clawpinch-ignore.json" ]]; then
-    ignore_file="$OPENCLAW_CONFIG/.clawpinch-ignore.json"
+  if [[ -n "$OPENCLAW_CONFIG" ]] && [[ -f "$(dirname "$OPENCLAW_CONFIG")/.clawpinch-ignore.json" ]]; then
+    ignore_file="$(dirname "$OPENCLAW_CONFIG")/.clawpinch-ignore.json"
   fi
 
   # Filter findings into active and suppressed
@@ -378,7 +378,7 @@ DISPLAY_FINDINGS="$ACTIVE_FINDINGS"
 if [[ "$SHOW_SUPPRESSED" -eq 1 ]]; then
   # Mark suppressed findings with a "suppressed": true field before merging
   MARKED_SUPPRESSED="$(echo "$SUPPRESSED_FINDINGS" | jq '[.[] | . + {suppressed: true}]')"
-  DISPLAY_FINDINGS="$(echo "$ACTIVE_FINDINGS" "$MARKED_SUPPRESSED" | jq -s '.[0] + .[1] | sort_by(.severity | if . == "critical" then 0 elif . == "warn" then 1 elif . == "info" then 2 elif . == "ok" then 3 else 4 end)')"
+  DISPLAY_FINDINGS="$(echo "$ACTIVE_FINDINGS" "$MARKED_SUPPRESSED" | jq -s 'def sev_order: if . == "critical" then 0 elif . == "warn" then 1 elif . == "info" then 2 elif . == "ok" then 3 else 4 end; .[0] + .[1] | sort_by(.severity | sev_order)')"
 fi
 
 # ─── Count by severity ──────────────────────────────────────────────────────

--- a/clawpinch.sh
+++ b/clawpinch.sh
@@ -29,6 +29,8 @@ NO_INTERACTIVE=0
 REMEDIATE=0
 PARALLEL_SCANNERS=1
 CONFIG_DIR=""
+SHOW_SUPPRESSED=0
+NO_IGNORE=0
 
 # ─── Usage ───────────────────────────────────────────────────────────────────
 
@@ -45,6 +47,8 @@ Options:
   --no-interactive  Disable interactive post-scan menu
   --remediate       Run scan then pipe findings to Claude for AI remediation
   --config-dir PATH Explicit path to openclaw config directory
+  --show-suppressed Include suppressed findings in normal output
+  --no-ignore       Disable all suppressions for full audit scan
   -h, --help        Show this help message
 
 Exit codes:
@@ -65,6 +69,8 @@ while [[ $# -gt 0 ]]; do
     --sequential) PARALLEL_SCANNERS=0; shift ;;
     --no-interactive) NO_INTERACTIVE=1; shift ;;
     --remediate)  REMEDIATE=1; NO_INTERACTIVE=1; shift ;;
+    --show-suppressed) SHOW_SUPPRESSED=1; shift ;;
+    --no-ignore)  NO_IGNORE=1; shift ;;
     --config-dir)
       if [[ -z "${2:-}" ]]; then
         log_error "--config-dir requires a path argument"
@@ -86,6 +92,8 @@ done
 export CLAWPINCH_DEEP="$DEEP"
 export CLAWPINCH_SHOW_FIX="$SHOW_FIX"
 export CLAWPINCH_CONFIG_DIR="$CONFIG_DIR"
+export CLAWPINCH_SHOW_SUPPRESSED="$SHOW_SUPPRESSED"
+export CLAWPINCH_NO_IGNORE="$NO_IGNORE"
 export QUIET
 
 # ─── Validate security config (early check for --remediate) ──────────────────

--- a/clawpinch.sh
+++ b/clawpinch.sh
@@ -386,6 +386,7 @@ count_critical="$(echo "$ACTIVE_FINDINGS" | jq '[.[] | select(.severity == "crit
 count_warn="$(echo "$ACTIVE_FINDINGS"     | jq '[.[] | select(.severity == "warn")] | length')"
 count_info="$(echo "$ACTIVE_FINDINGS"     | jq '[.[] | select(.severity == "info")] | length')"
 count_ok="$(echo "$ACTIVE_FINDINGS"       | jq '[.[] | select(.severity == "ok")] | length')"
+count_suppressed="$(echo "$SUPPRESSED_FINDINGS" | jq 'length')"
 
 # ─── Output ──────────────────────────────────────────────────────────────────
 
@@ -419,7 +420,7 @@ else
   fi
 
   # Always print summary dashboard (animated when TTY)
-  print_summary_animated "$count_critical" "$count_warn" "$count_info" "$count_ok" "$scanner_count" "$_scan_elapsed"
+  print_summary_animated "$count_critical" "$count_warn" "$count_info" "$count_ok" "$scanner_count" "$_scan_elapsed" "$count_suppressed"
 
   # Contextual completion message
   print_completion_message "$count_critical" "$count_warn"

--- a/scripts/helpers/interactive.sh
+++ b/scripts/helpers/interactive.sh
@@ -250,14 +250,6 @@ print_findings_compact() {
         f_title="${f_title:0:$((max_title_len - 3))}..."
       fi
 
-      # Fix indicator (fixed-width, no color padding issues)
-      local fix_mark
-      if [[ -n "$f_auto_fix" ]]; then
-        fix_mark=" ${_CLR_OK}✓${_CLR_RST} "
-      else
-        fix_mark=" ─ "
-      fi
-
       # Dim the row if suppressed
       local row_color=""
       if [[ "$f_suppressed" == "true" ]]; then

--- a/scripts/helpers/interactive.sh
+++ b/scripts/helpers/interactive.sh
@@ -233,10 +233,16 @@ print_findings_compact() {
     for (( i=0; i<show_count; i++ )); do
       local finding
       finding="$(echo "$json_array" | jq -c "[.[] | select(.severity == \"$sev\")][$i]")"
-      local f_id f_title f_auto_fix
+      local f_id f_title f_auto_fix f_suppressed
       f_id="$(echo "$finding" | jq -r '.id // ""')"
       f_title="$(echo "$finding" | jq -r '.title // ""')"
       f_auto_fix="$(echo "$finding" | jq -r '.auto_fix // ""')"
+      f_suppressed="$(echo "$finding" | jq -r '.suppressed // false')"
+
+      # Add [SUPPRESSED] prefix to title if suppressed
+      if [[ "$f_suppressed" == "true" ]]; then
+        f_title="[SUPPRESSED] $f_title"
+      fi
 
       # Truncate title if needed
       local max_title_len=$(( col_title - 2 ))
@@ -245,10 +251,23 @@ print_findings_compact() {
       fi
 
       # Fix indicator (fixed-width, no color padding issues)
+      local fix_mark
+      if [[ -n "$f_auto_fix" ]]; then
+        fix_mark=" ${_CLR_OK}✓${_CLR_RST} "
+      else
+        fix_mark=" ─ "
+      fi
+
+      # Dim the row if suppressed
+      local row_color=""
+      if [[ "$f_suppressed" == "true" ]]; then
+        row_color="$_CLR_DIM"
+      fi
+
       printf '  %s' "$_TBL_V"
-      printf " %-*s" $(( col_id - 2 )) "$f_id"
+      printf " %b%-*s%b" "$row_color" $(( col_id - 2 )) "$f_id" "$_CLR_RST"
       printf ' %s' "$_TBL_V"
-      printf " %-*s" $(( col_title - 2 )) "$f_title"
+      printf " %b%-*s%b" "$row_color" $(( col_title - 2 )) "$f_title" "$_CLR_RST"
       printf ' %s' "$_TBL_V"
       if [[ -n "$f_auto_fix" ]]; then
         printf ' %b✓%b  ' "$_CLR_OK" "$_CLR_RST"

--- a/scripts/helpers/report.sh
+++ b/scripts/helpers/report.sh
@@ -562,25 +562,14 @@ print_finding() {
   local inner=$(( w - 6 ))  # "  ┃ " left (4) + " ┃" right (2)
 
   local id severity title description evidence remediation auto_fix suppressed
-  {
-    read -r id
-    read -r severity
-    read -r title
-    read -r description
-    read -r evidence
-    read -r remediation
-    read -r auto_fix
-    read -r suppressed
-  } < <(echo "$json" | jq -r '
-    .id // "",
-    .severity // "info",
-    .title // "",
-    .description // "",
-    .evidence // "",
-    .remediation // "",
-    .auto_fix // "",
-    .suppressed // false
-  ')
+  id="$(echo "$json" | jq -r '.id // ""')"
+  severity="$(echo "$json" | jq -r '.severity // "info"')"
+  title="$(echo "$json" | jq -r '.title // ""')"
+  description="$(echo "$json" | jq -r '.description // ""')"
+  evidence="$(echo "$json" | jq -r '.evidence // ""')"
+  remediation="$(echo "$json" | jq -r '.remediation // ""')"
+  auto_fix="$(echo "$json" | jq -r '.auto_fix // ""')"
+  suppressed="$(echo "$json" | jq -r '.suppressed // false')"
 
   # For OK findings, use compact single-line format
   if [[ "$severity" == "ok" ]]; then

--- a/scripts/helpers/report.sh
+++ b/scripts/helpers/report.sh
@@ -562,14 +562,25 @@ print_finding() {
   local inner=$(( w - 6 ))  # "  ┃ " left (4) + " ┃" right (2)
 
   local id severity title description evidence remediation auto_fix suppressed
-  id="$(echo "$json"          | jq -r '.id // ""')"
-  severity="$(echo "$json"    | jq -r '.severity // "info"')"
-  title="$(echo "$json"       | jq -r '.title // ""')"
-  description="$(echo "$json" | jq -r '.description // ""')"
-  evidence="$(echo "$json"    | jq -r '.evidence // ""')"
-  remediation="$(echo "$json" | jq -r '.remediation // ""')"
-  auto_fix="$(echo "$json"    | jq -r '.auto_fix // ""')"
-  suppressed="$(echo "$json"  | jq -r '.suppressed // false')"
+  {
+    read -r id
+    read -r severity
+    read -r title
+    read -r description
+    read -r evidence
+    read -r remediation
+    read -r auto_fix
+    read -r suppressed
+  } < <(echo "$json" | jq -r '
+    .id // "",
+    .severity // "info",
+    .title // "",
+    .description // "",
+    .evidence // "",
+    .remediation // "",
+    .auto_fix // "",
+    .suppressed // false
+  ')
 
   # For OK findings, use compact single-line format
   if [[ "$severity" == "ok" ]]; then

--- a/scripts/helpers/report.sh
+++ b/scripts/helpers/report.sh
@@ -561,7 +561,7 @@ print_finding() {
   w="$(_box_width)"
   local inner=$(( w - 6 ))  # "  ┃ " left (4) + " ┃" right (2)
 
-  local id severity title description evidence remediation auto_fix
+  local id severity title description evidence remediation auto_fix suppressed
   id="$(echo "$json"          | jq -r '.id // ""')"
   severity="$(echo "$json"    | jq -r '.severity // "info"')"
   title="$(echo "$json"       | jq -r '.title // ""')"
@@ -569,10 +569,11 @@ print_finding() {
   evidence="$(echo "$json"    | jq -r '.evidence // ""')"
   remediation="$(echo "$json" | jq -r '.remediation // ""')"
   auto_fix="$(echo "$json"    | jq -r '.auto_fix // ""')"
+  suppressed="$(echo "$json"  | jq -r '.suppressed // false')"
 
   # For OK findings, use compact single-line format
   if [[ "$severity" == "ok" ]]; then
-    print_finding_ok "$title" "$id"
+    print_finding_ok "$title" "$id" "$suppressed"
     return
   fi
 
@@ -593,10 +594,18 @@ print_finding() {
   printf ' %b%s%b\n' "$sev_clr" "$_CARD_V" "$_CLR_RST"
 
   # ─ Title text line
-  local title_pad=$(( inner - ${#title} ))
+  local display_title="$title"
+  if [[ "$suppressed" == "true" ]]; then
+    display_title="[SUPPRESSED] $title"
+  fi
+  local title_pad=$(( inner - ${#display_title} ))
   if (( title_pad < 0 )); then title_pad=0; fi
   printf '  %b%s%b ' "$sev_clr" "$_CARD_V" "$_CLR_RST"
-  printf '%b%s%b' "$_CLR_WHITE" "$title" "$_CLR_RST"
+  if [[ "$suppressed" == "true" ]]; then
+    printf '%b%s%b' "$_CLR_DIM" "$display_title" "$_CLR_RST"
+  else
+    printf '%b%s%b' "$_CLR_WHITE" "$display_title" "$_CLR_RST"
+  fi
   printf '%*s' "$title_pad" ''
   printf ' %b%s%b\n' "$sev_clr" "$_CARD_V" "$_CLR_RST"
 
@@ -685,17 +694,27 @@ print_finding() {
 print_finding_ok() {
   local title="$1"
   local id="${2:-}"
+  local suppressed="${3:-false}"
   local w
   w="$(_box_width)"
+
+  local display_title="$title"
+  if [[ "$suppressed" == "true" ]]; then
+    display_title="[SUPPRESSED] $title"
+  fi
 
   local prefix="✓ "
   local prefix_len=2
   local id_len=${#id}
-  local title_len=${#title}
+  local title_len=${#display_title}
   local gap=$(( w - 4 - prefix_len - title_len - id_len ))
   if (( gap < 1 )); then gap=1; fi
 
-  printf '  %b✓%b %s' "$_CLR_OK" "$_CLR_RST" "$title"
+  if [[ "$suppressed" == "true" ]]; then
+    printf '  %b✓%b %b%s%b' "$_CLR_OK" "$_CLR_RST" "$_CLR_DIM" "$display_title" "$_CLR_RST"
+  else
+    printf '  %b✓%b %s' "$_CLR_OK" "$_CLR_RST" "$display_title"
+  fi
   printf '%*s' "$gap" ''
   printf '%b%s%b\n' "$_CLR_DIM" "$id" "$_CLR_RST"
 }

--- a/scripts/helpers/report.sh
+++ b/scripts/helpers/report.sh
@@ -730,6 +730,7 @@ print_summary() {
   local ok="${4:-0}"
   local scanner_count="${5:-0}"
   local elapsed="${6:-0}"
+  local suppressed="${7:-0}"
 
   local total=$(( critical + warn + info + ok ))
   local w
@@ -836,6 +837,20 @@ print_summary() {
   printf '%*s%b%s%b' "$time_lpad" '' "$_CLR_DIM" "$time_text" "$_CLR_RST"
   printf '%*s' "$time_rpad" ''
   printf " %b%s%b\n" "$_CLR_BOX" "$_HBOX_V" "$_CLR_RST"
+
+  # Suppressed count line (only show if > 0)
+  if (( suppressed > 0 )); then
+    local supp_text
+    supp_text="$(printf 'Suppressed: %d findings' "$suppressed")"
+    local supp_len=${#supp_text}
+    local supp_lpad=2
+    local supp_rpad=$(( inner - supp_lpad - supp_len ))
+    if (( supp_rpad < 0 )); then supp_rpad=0; fi
+    printf "  %b%s%b " "$_CLR_BOX" "$_HBOX_V" "$_CLR_RST"
+    printf '%*s%b%s%b' "$supp_lpad" '' "$_CLR_DIM" "$supp_text" "$_CLR_RST"
+    printf '%*s' "$supp_rpad" ''
+    printf " %b%s%b\n" "$_CLR_BOX" "$_HBOX_V" "$_CLR_RST"
+  fi
 
   # Empty line
   printf "  %b%s%b " "$_CLR_BOX" "$_HBOX_V" "$_CLR_RST"

--- a/scripts/helpers/suppression.sh
+++ b/scripts/helpers/suppression.sh
@@ -81,13 +81,7 @@ filter_findings() {
 
   # Get current timestamp
   local now
-  if command -v date &>/dev/null; then
-    if ! now="$(date -u +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null)"; then
-      now=""
-    fi
-  else
-    now=""
-  fi
+  now="$(date -u +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || true)"
 
   # Read findings from stdin and filter
   local findings

--- a/scripts/helpers/suppression.sh
+++ b/scripts/helpers/suppression.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ─── ClawPinch suppression helpers ──────────────────────────────────────────
+# Manage finding suppressions from .clawpinch-ignore.json
+# Source this file from the main orchestrator:
+#   source "$(dirname "$0")/scripts/helpers/suppression.sh"
+
+# Global variable to store loaded suppressions (JSON array)
+_CLAWPINCH_SUPPRESSIONS="[]"
+
+# ─── Load suppressions from ignore file ─────────────────────────────────────
+# Usage: load_suppressions <file_path>
+# Returns: 0 on success (including when file doesn't exist), 1 on invalid JSON
+
+load_suppressions() {
+  local ignore_file="${1:-.clawpinch-ignore.json}"
+
+  # Reset suppressions
+  _CLAWPINCH_SUPPRESSIONS="[]"
+
+  # If file doesn't exist, that's OK - no suppressions to load
+  if [[ ! -f "$ignore_file" ]]; then
+    return 0
+  fi
+
+  # Require jq for JSON parsing
+  if ! command -v jq &>/dev/null; then
+    # Fallback: if jq not available, disable suppressions
+    # This is a graceful degradation - better than failing the whole scan
+    return 0
+  fi
+
+  # Parse the JSON file and extract suppressions array
+  local parsed
+  if ! parsed="$(jq -c '.suppressions // []' "$ignore_file" 2>/dev/null)"; then
+    # Invalid JSON - log warning and continue with no suppressions
+    if [[ -n "${_CLR_YLW:-}" ]]; then
+      printf "${_CLR_YLW}[warn]${_CLR_RST}  Invalid JSON in %s - ignoring suppressions\n" "$ignore_file" >&2
+    else
+      printf "[warn]  Invalid JSON in %s - ignoring suppressions\n" "$ignore_file" >&2
+    fi
+    return 1
+  fi
+
+  # Validate that we got an array
+  if ! echo "$parsed" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    if [[ -n "${_CLR_YLW:-}" ]]; then
+      printf "${_CLR_YLW}[warn]${_CLR_RST}  .suppressions is not an array in %s\n" "$ignore_file" >&2
+    else
+      printf "[warn]  .suppressions is not an array in %s\n" "$ignore_file" >&2
+    fi
+    return 1
+  fi
+
+  _CLAWPINCH_SUPPRESSIONS="$parsed"
+  return 0
+}
+
+# ─── Check if a finding ID is currently suppressed ──────────────────────────
+# Usage: is_suppressed <check_id>
+# Returns: 0 if suppressed and not expired, 1 otherwise
+
+is_suppressed() {
+  local check_id="$1"
+
+  # If no suppressions loaded, nothing is suppressed
+  if [[ "$_CLAWPINCH_SUPPRESSIONS" == "[]" ]]; then
+    return 1
+  fi
+
+  # Require jq
+  if ! command -v jq &>/dev/null; then
+    return 1
+  fi
+
+  # Get current timestamp in ISO 8601 format for expiration checking
+  local now
+  if command -v date &>/dev/null; then
+    # Try to get ISO 8601 timestamp (works on GNU date and macOS date)
+    if date -u +"%Y-%m-%dT%H:%M:%SZ" &>/dev/null; then
+      now="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    else
+      # Fallback if date format fails
+      now=""
+    fi
+  else
+    now=""
+  fi
+
+  # Check if the ID is in suppressions and not expired
+  local result
+  if [[ -n "$now" ]]; then
+    # With expiration checking
+    result="$(echo "$_CLAWPINCH_SUPPRESSIONS" | jq -r --arg id "$check_id" --arg now "$now" '
+      map(select(.id == $id)) |
+      if length > 0 then
+        .[0] |
+        if .expires then
+          if .expires > $now then "suppressed" else "expired" end
+        else
+          "suppressed"
+        end
+      else
+        "active"
+      end
+    ' 2>/dev/null)"
+  else
+    # Without expiration checking (no date command or failed to get timestamp)
+    result="$(echo "$_CLAWPINCH_SUPPRESSIONS" | jq -r --arg id "$check_id" '
+      if (map(select(.id == $id)) | length > 0) then
+        "suppressed"
+      else
+        "active"
+      end
+    ' 2>/dev/null)"
+  fi
+
+  [[ "$result" == "suppressed" ]]
+}
+
+# ─── Filter findings into active and suppressed arrays ──────────────────────
+# Usage: filter_findings <ignore_file> < findings.json
+# Reads findings JSON array from stdin
+# Outputs: {"active": [...], "suppressed": [...]}
+
+filter_findings() {
+  local ignore_file="${1:-.clawpinch-ignore.json}"
+
+  # Load suppressions if not already loaded
+  if [[ "$_CLAWPINCH_SUPPRESSIONS" == "[]" ]] && [[ -f "$ignore_file" ]]; then
+    load_suppressions "$ignore_file"
+  fi
+
+  # Require jq
+  if ! command -v jq &>/dev/null; then
+    # Fallback: all findings are active
+    local findings
+    findings="$(cat)"
+    echo "{\"active\": $findings, \"suppressed\": []}"
+    return 0
+  fi
+
+  # Get current timestamp
+  local now
+  if command -v date &>/dev/null && date -u +"%Y-%m-%dT%H:%M:%SZ" &>/dev/null; then
+    now="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  else
+    now=""
+  fi
+
+  # Read findings from stdin and filter
+  local findings
+  findings="$(cat)"
+
+  # Use jq to split findings into active and suppressed
+  if [[ -n "$now" ]]; then
+    # With expiration checking
+    echo "$findings" | jq -c --argjson suppressions "$_CLAWPINCH_SUPPRESSIONS" --arg now "$now" '{
+      active: map(
+        . as $finding |
+        ($suppressions | map(select(.id == $finding.id)) | .[0]) as $suppression |
+        if $suppression then
+          if $suppression.expires then
+            if $suppression.expires <= $now then $finding else empty end
+          else
+            empty
+          end
+        else
+          $finding
+        end
+      ),
+      suppressed: map(
+        . as $finding |
+        ($suppressions | map(select(.id == $finding.id)) | .[0]) as $suppression |
+        if $suppression then
+          if $suppression.expires then
+            if $suppression.expires > $now then $finding else empty end
+          else
+            $finding
+          end
+        else
+          empty
+        end
+      )
+    }'
+  else
+    # Without expiration checking (treat all as unexpired)
+    echo "$findings" | jq -c --argjson suppressions "$_CLAWPINCH_SUPPRESSIONS" '{
+      active: map(
+        . as $finding |
+        if ($suppressions | map(select(.id == $finding.id)) | length == 0) then
+          $finding
+        else
+          empty
+        end
+      ),
+      suppressed: map(
+        . as $finding |
+        if ($suppressions | map(select(.id == $finding.id)) | length > 0) then
+          $finding
+        else
+          empty
+        end
+      )
+    }'
+  fi
+}


### PR DESCRIPTION
Allow users to suppress specific findings by check ID, with optional expiration dates and justification comments. Suppressions are stored in .clawpinch-ignore.json (similar to .eslintignore). Suppressed findings are still scanned but reported separately as 'suppressed' rather than counting toward severity totals. A --show-suppressed flag reveals them.