### PR TITLE
Add SSH Key Permissions Check

### DIFF
--- a/references/check-catalog.md
+++ b/references/check-catalog.md
@@ -246,6 +246,12 @@ severity, description, and remediation.
 - **Description:** Changes to permission rules are not logged. Malicious permission escalation cannot be detected after the fact.
 - **Remediation:** Enable audit logging for permission changes.
 
+### CHK-PRM-013 -- SSH private key has overly permissive permissions
+- **Severity:** Critical
+- **Description:** SSH private key files (e.g., `~/.ssh/id_rsa`, `~/.ssh/id_ed25519`) have permissions more permissive than 600. SSH clients often refuse to use keys with incorrect permissions, and they can be read by other users on the system.
+- **Remediation:** Set SSH key permissions to 600 (read/write owner only): `chmod 600 ~/.ssh/id_rsa`
+- **Auto-fix:** `chmod 600 "$KEY_PATH"`
+
 ---
 
 ## Cron (CHK-CRN)

--- a/scripts/helpers/test_integration.sh
+++ b/scripts/helpers/test_integration.sh
@@ -351,6 +351,10 @@ EOF
             return 1
         fi
     done
+    # NOTE: This test verifies the chmod auto-fix command works correctly, but
+    # does not exercise the scanner's find/detect logic itself. This is
+    # consistent with other integration tests in this file which focus on
+    # auto-fix command validation rather than scanner detection coverage.
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/scan_permissions.sh
+++ b/scripts/scan_permissions.sh
@@ -674,7 +674,7 @@ check_ssh_keys() {
       # [a-zA-Z0-9/._-]+, so we must not emit auto_fix for filenames with
       # characters outside that set (e.g., spaces, quotes, shell metacharacters).
       # Standard SSH key names (id_rsa, id_ed25519, *.pem) always pass this check.
-      local auto_fix_cmd="" remediation_msg="Run: chmod 600 \"$f\" (manual)"
+      local auto_fix_cmd="" remediation_msg="Manual fix required: chmod 600 [file]"
       if [[ "$f" =~ ^[a-zA-Z0-9/._-]+$ ]]; then
         auto_fix_cmd="chmod 600 $f"
         remediation_msg="Run: chmod 600 $f"
@@ -692,8 +692,8 @@ check_ssh_keys() {
         "$f mode $perms" "" ""
     fi
   done < <(find "$ssh_dir" -maxdepth 1 \( \
-    -name 'id_*' -o -name '*.pem' \
-  \) -type f ! -name '*.pub' -print0 2>/dev/null)
+    -iname 'id_*' -o -iname '*.pem' \
+  \) -type f ! -iname '*.pub' -print0 2>/dev/null)
 
   if [[ "$found" -eq 0 ]]; then
     add_finding "CHK-PRM-013" "info" \

--- a/scripts/scan_permissions.sh
+++ b/scripts/scan_permissions.sh
@@ -673,8 +673,8 @@ check_ssh_keys() {
         "SSH private key has insecure permissions" \
         "SSH private keys must be chmod 600 or SSH clients will refuse to use them. Current: $perms" \
         "$f mode $perms" \
-        "Run: chmod 600 '$f'" \
-        "chmod 600 '$f'"
+        "Run: chmod 600 $f" \
+        "chmod 600 $f"
     else
       add_finding "CHK-PRM-013" "ok" \
         "SSH private key permissions correct" \


### PR DESCRIPTION
Extend the existing permissions scanner to check SSH private key files (~/.ssh/id_*, ~/.ssh/*.pem) for proper 600 permissions. SSH keys with overly permissive permissions are a security risk and ssh clients often refuse to use them.